### PR TITLE
added max-width to body for ultra wide layouts

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,7 +6,12 @@ font-size: 16px;
 color: #fff;
 overflow-x: hidden;
 }
-
+body {
+  width: 100%;
+  max-width: 2100px;
+  margin-left: 50%;
+  transform: translateX(-50%);
+}
 .overflow {
   overflow: hidden;
   height: 90vh;


### PR DESCRIPTION
Vorschlag: Auf sehr breiten Bildschirmen rechts & links einen größeren Rand haben, sodass trotz breitem Format noch zwei Reihen Bilder zu sehen sind

Vorher - eine Reihe, zweite abgeschnitten ![kein max-width](https://i.imgur.com/0VFPpk7.png)
Nachher - zwei Reihen, immer noch größer als Full HD aber Rand links & rechts (`max-width: 2100px`) ![max-width: 2100px](https://i.imgur.com/vuQaYr8.png)

Alternativ kann man die Breite auch noch mehr einschränken und an FullHD angleichen, aber volle Breite erschlägt mich 😅 (statt drei sind ja auch immer nur zwei wirklich zu sehen, weil eines im hover-state ganz schwarz ist)

FullHD (`max-width: 1920px`): ![max-width: 1920px](https://i.imgur.com/kRYJq2N.png)